### PR TITLE
XiaomiEuicc: Don't fatally crash when euicc package is not exists

### DIFF
--- a/Euicc/src/co/aospa/euicc/EuiccDisabler.kt
+++ b/Euicc/src/co/aospa/euicc/EuiccDisabler.kt
@@ -6,6 +6,7 @@
 package co.aospa.euicc
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PackageInfoFlags
 import android.util.Log
@@ -23,6 +24,11 @@ object EuiccDisabler {
         "com.google.android.ims",
     )
 
+    private fun isInstalled(pm: PackageManager, pkgName: String) = runCatching {
+        val info = pm.getPackageInfo(pkgName, PackageInfoFlags.of(0))
+        info.applicationInfo.flags and ApplicationInfo.FLAG_INSTALLED != 0
+    }.getOrDefault(false)
+
     private fun isInstalledAndEnabled(pm: PackageManager, pkgName: String) = runCatching {
         val info = pm.getPackageInfo(pkgName, PackageInfoFlags.of(0))
         Log.d(TAG, "package $pkgName installed, enabled = ${info.applicationInfo.enabled}")
@@ -39,7 +45,9 @@ object EuiccDisabler {
         }
 
         for (pkg in EUICC_PACKAGES) {
-            pm.setApplicationEnabledSetting(pkg, flag, 0)
+            if (isInstalled(pm, pkg)) {
+                pm.setApplicationEnabledSetting(pkg, flag, 0)
+            }
         }
     }
 }


### PR DESCRIPTION
Test: Manual. Build, boot, no more crash observed when no euicc package found.