### PR TITLE
sensors: Lazily open the enable stream

### DIFF
--- a/sensors/v2/Sensor.h
+++ b/sensors/v2/Sensor.h
@@ -119,6 +119,8 @@ class SysfsPollingOneShotSensor : public OneShotSensor {
     struct pollfd mPolls[2];
     int mWaitPipeFd[2];
     int mPollFd;
+    std::string mEnablePath;
+    std::once_flag mEnableOpenOnce;
 };
 
 class DoubleTapSensor : public SysfsPollingOneShotSensor {


### PR DESCRIPTION
Sysfs node initialization lags behind HAL startup on SM8550 and newer platforms. Opening the node in the constructor causes a race condition, leading to enable path writing failure.

Lazily open the enable stream to resolve this race condition.

Change-Id: I8e2c5996a52a5870143adf9b6a5c6689c9e6d5a5